### PR TITLE
"--keep-going" argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,8 +99,9 @@ Type ``repeat --help`` to see options::
       cmd          command to execute
 
     optional arguments:
-      -h, --help   show this help message and exit
-      -q, --quiet  suppress progress output
+      -h, --help        show this help message and exit
+      -q, --quiet       suppress progress output
+      -k, --keep-going  keep running even if some iterations fail
 
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -42,8 +42,21 @@ Example usage::
 
 The script will stop as soon as the command being executed exits with a nonzero
 return code, and will itself exit with that same return code.  On successful
-completion it will exit with return code 0.  Some day I may add an option to
-continue on error, but I haven't needed that option yet.
+completion it will exit with return code 0. To keep going even if some of the
+iterations of the command fail, use the ``-k`` option::
+
+    $ repeat -k 3 python -c "import sys; sys.exit(1)"
+    repeat: Repeating ['python', '-c', 'import sys; sys.exit(1)'] 3 times.
+    repeat: Starting run 1 of 3.
+    repeat: Run 1 of 3 failed with return code 1.
+    repeat: # of successes: 0, # of failures: 1 (100.00%).
+    repeat: Starting run 2 of 3.
+    repeat: Run 2 of 3 failed with return code 1.
+    repeat: # of successes: 0, # of failures: 2 (100.00%).
+    repeat: Starting run 3 of 3.
+    repeat: Run 3 of 3 failed with return code 1.
+    repeat: # of successes: 0, # of failures: 3 (100.00%).
+    repeat: Exiting with return code 1.
 
 More simply, omit the count argument to repeat indefinitely::
 

--- a/repeat.py
+++ b/repeat.py
@@ -14,6 +14,10 @@ PREFIX = "repeat: "
 FAILED = "{prefix}Run {run} failed with return code {returncode}.\n"
 PASSED = "{prefix}Run {run} completed.\n"
 
+# Template for reporting no. of successes/failures when keep_going is true.
+PROGRESS = ("{prefix}# of successes: {n_success}, "
+            "# of failures: {n_failure} ({pct_failure:.2f}%).\n")
+
 count_descriptions = {
     None: "forever",
     1: "once",
@@ -53,6 +57,7 @@ def repeat(cmd, count=None, verbose=True, keep_going=False,
     else:
         run_indices = six.moves.range(1, count + 1)
 
+    n_success = n_failure = 0
     returncode = 0
     for index in run_indices:
         if verbose:
@@ -82,8 +87,21 @@ def repeat(cmd, count=None, verbose=True, keep_going=False,
 
         if run_returncode != 0:
             returncode = 1
+            n_failure += 1
             if not keep_going:
                 break
+        else:
+            n_success += 1
+
+        if verbose and keep_going:
+            progress_stream.write(
+                PROGRESS.format(
+                    prefix=prefix,
+                    n_success=n_success,
+                    n_failure=n_failure,
+                    pct_failure=100.0*n_failure/(n_failure+n_success),
+                )
+            )
 
     if verbose:
         progress_stream.write(

--- a/test_repeat.py
+++ b/test_repeat.py
@@ -151,3 +151,27 @@ class TestRepeat(unittest.TestCase):
             infinite testing> Run 3 failed with return code -23.
         """)
         self.assertIn(expected_run_reporting, full_output)
+
+    def test_n_success_failure_in_output(self):
+        self.mock_subprocess_call.returncodes = iter([0, -9, 0])
+        repeat.repeat(
+            cmd=self.mock_cmd,
+            count=3,
+            verbose=True,
+            keep_going=True,
+            progress_stream=self.mock_stdout,
+            prefix='keep going> ',
+        )
+        full_output = self.mock_stdout.getvalue()
+        expected_run_reporting = textwrap.dedent("""\
+            keep going> Starting run 1 of 3.
+            keep going> Run 1 of 3 completed.
+            keep going> # of successes: 1, # of failures: 0 (0.00%).
+            keep going> Starting run 2 of 3.
+            keep going> Run 2 of 3 failed with return code -9.
+            keep going> # of successes: 1, # of failures: 1 (50.00%).
+            keep going> Starting run 3 of 3.
+            keep going> Run 3 of 3 completed.
+            keep going> # of successes: 2, # of failures: 1 (33.33%).
+        """)
+        self.assertIn(expected_run_reporting, full_output)

--- a/test_repeat.py
+++ b/test_repeat.py
@@ -77,6 +77,14 @@ class TestRepeat(unittest.TestCase):
         self.assertEqual(returncode, 1)
         self.assertEqual(self.mock_subprocess_call.call_count, 2)
 
+    def test_keep_going(self):
+        self.mock_subprocess_call.returncodes = iter([0, 1, 0])
+        returncode = repeat.repeat(
+            self.mock_cmd, count=3, keep_going=True,
+            progress_stream=self.mock_stdout)
+        self.assertEqual(returncode, 1)
+        self.assertEqual(self.mock_subprocess_call.call_count, 3)
+
     def test_no_progress_output_when_verbose_is_false(self):
         returncode = repeat.repeat(
             cmd=self.mock_cmd,


### PR DESCRIPTION
This is the `--keep-going` argument that I mentioned a long time ago (sorry for the delay!)

In my branch I also have a signal handler so that the user can send SIG_USR1 to `repeat` and get a progress report (useful for long-running tasks, where the progress message may have scrolled outside the visible terminal). @mdickinson Is that something that could be of interest, too?